### PR TITLE
Add timeout to GetFiles() method

### DIFF
--- a/ScannerRemote/ScannerRemote/Helpers/Updater.cs
+++ b/ScannerRemote/ScannerRemote/Helpers/Updater.cs
@@ -53,6 +53,13 @@ namespace ScannerRemote.Helpers
 
                 var rest = new apihelper();
                 var tmp =  await rest.GetFiles();
+                if (tmp == null)
+                {
+                    // Loading files went wrong
+                    UpdateProgressBar(1.0);
+                    UpdateLabel("An error occured");
+                    return;
+                }
               
                 var docsindb = DAL.RealmDAL.Instance.GetAllDocuments();
                 var count = 0;


### PR DESCRIPTION
Add a `CancellationToken` to the `RestClient` and return null in case of a timeout.

The calling `Updater` show an error when the result is null